### PR TITLE
Fixed bug related to isPurchased for consumables

### DIFF
--- a/Sources/StoreHelper/Core/StoreHelper.swift
+++ b/Sources/StoreHelper/Core/StoreHelper.swift
@@ -591,17 +591,26 @@ public class StoreHelper: ObservableObject {
         
         if purchased {
             if product.type == .consumable {
-                while purchasedProducts.count < KeychainHelper.count(for: productId) {
-                    purchasedProducts.append(productId)  // Consumables can appear more than once in this list
+                let keychainCount = KeychainHelper.count(for: productId)
+                let purchasedProductsCount = purchasedProducts.filter({ $0 == productId }).count
+                if keychainCount == purchasedProductsCount || purchasedProductsCount > keychainCount { return } else {
+                    while purchasedProducts.count < KeychainHelper.count(for: productId) {
+                        purchasedProducts.append(productId)  // Consumables can appear more than once in this list
+                    }
                 }
+
             } else {
                 if !purchasedProducts.contains(productId) { purchasedProducts.append(productId) }
             }
             
         } else {
             if product.type == .consumable {
-                while purchasedProducts.count > KeychainHelper.count(for: productId) {
-                    if let index = purchasedProducts.firstIndex(where: { $0 == productId}) { purchasedProducts.remove(at: index) }
+                let keychainCount = KeychainHelper.count(for: productId)
+                let purchasedProductsCount = purchasedProducts.filter({ $0 == productId }).count
+                if keychainCount == purchasedProductsCount || purchasedProductsCount < keychainCount { return } else {
+                    while purchasedProducts.count > KeychainHelper.count(for: productId) {
+                        if let index = purchasedProducts.firstIndex(where: { $0 == productId}) { purchasedProducts.remove(at: index) }
+                    }
                 }
             } else {
                 if let index = purchasedProducts.firstIndex(where: { $0 == productId}) { purchasedProducts.remove(at: index) }


### PR DESCRIPTION
Bug was in updatePurchasedIdentifiers(_:purchased:) and resulted in a crash on both macOS and iOS