### PR TITLE
Improved handling of subscriptions when the app's not running

### DIFF
--- a/Documentation/guide.md
+++ b/Documentation/guide.md
@@ -18,6 +18,9 @@ This document describes how to implement and test in-app purchases with **SwiftU
 ---
 
 # Recent Major Changes
+- 23 June, 2023
+    - Improved handling of subscription renewals and expirations that happen when the app's not running
+    - See `AppStoreHelper.paymentQueue(_:updatedTransactions:)` and `StoreHelper.handleStoreKit1Transactions(productId:date:status:transaction:)`
 - 18 January, 2023
     - Additional logging of various activities added
 - 17 January, 2023

--- a/Sources/StoreHelper/Core/StoreNotification.swift
+++ b/Sources/StoreHelper/Core/StoreNotification.swift
@@ -84,11 +84,13 @@ public enum StoreNotification: Error, Equatable {
     case transactionValidationFailure
     case transactionFailure
     case transactionSuccess
+    case transactionSubscribed
     case transactionRevoked
     case transactionRefundRequested
     case transactionRefundFailed
     case transactionExpired
     case transactionUpgraded
+    case transactionInGracePeriod
     
     case consumableSavedInKeychain
     case consumableKeychainError
@@ -138,11 +140,13 @@ public enum StoreNotification: Error, Equatable {
             case .transactionValidationFailure:         return "Transaction validation failure"
             case .transactionFailure:                   return "Transaction failure"
             case .transactionSuccess:                   return "Transaction success"
+            case .transactionSubscribed:                return "Transaction for subscription was a success"
             case .transactionRevoked:                   return "Transaction was revoked (refunded) by the App Store"
             case .transactionRefundRequested:           return "Transaction refund successfully requested"
             case .transactionRefundFailed:              return "Transaction refund request failed"
             case .transactionExpired:                   return "Transaction for subscription has expired"
             case .transactionUpgraded:                  return "Transaction superceeded by higher-value subscription"
+            case .transactionInGracePeriod:             return "Transaction for subscription is in a grace period"
                         
             case .consumableSavedInKeychain:            return "Consumable purchase successfully saved to the keychain"
             case .consumableKeychainError:              return "Keychain error"


### PR DESCRIPTION
Improved handling of subscription renewals and expirations that happen when the app's not running. See AppStoreHelper.paymentQueue(_:updatedTransactions:) and StoreHelper.handleStoreKit1Transactions(productId:date:status:transaction:).
