### PR TITLE
Added await transaction.finish() inside Transaction.updates

### DIFF
--- a/Sources/StoreHelper/Core/StoreHelper.swift
+++ b/Sources/StoreHelper/Core/StoreHelper.swift
@@ -869,6 +869,7 @@ public class StoreHelper: ObservableObject {
                     StoreLog.transaction(.transactionRevoked, productId: transaction.productID, transactionId: String(transaction.id))
                     await self.updatePurchasedProducts(for: transaction.productID, purchased: false)
                     if let handler = transactionNotification { handler(.transactionRevoked, transaction.productID, String(transaction.id)) }
+                    await transaction.finish()
                     return
                 }
                 
@@ -877,6 +878,7 @@ public class StoreHelper: ObservableObject {
                     StoreLog.transaction(.transactionExpired, productId: transaction.productID, transactionId: String(transaction.id))
                     await self.updatePurchasedProducts(for: transaction.productID, purchased: false)
                     if let handler = transactionNotification { handler(.transactionExpired, transaction.productID, String(transaction.id)) }
+                    await transaction.finish()
                     return
                 }
                 
@@ -885,6 +887,7 @@ public class StoreHelper: ObservableObject {
                     StoreLog.transaction(.transactionUpgraded, productId: transaction.productID, transactionId: String(transaction.id))
                     await self.updatePurchasedProducts(for: transaction.productID, purchased: true)
                     if let handler = transactionNotification { handler(.transactionUpgraded, transaction.productID, String(transaction.id)) }
+                    await transaction.finish()
                     return
                 }
                     


### PR DESCRIPTION
Thanks for sharing this great library with us! Unfortunately I have experienced some problems with auto-renewable subscriptions when calling `product.purchase()`. The function would return immediately with success but the product wasn't purchased! 
I found that I wasn't the only one with this problem when using `StoreKit2` as you can see in this [thread](https://forums.developer.apple.com/forums/thread/723126).

Couple of members suggested that the app should always call `transaction.finish()` inside `Transaction.updates` which I did and after that it seems that this problem is gone. If you take a closer look inside [Source Code](https://developer.apple.com/documentation/storekit/in-app_purchase/implementing_a_store_in_your_app_using_the_storekit_api) from Apple you can see how they say: "Always finish a transaction.".