### PR TITLE
Smaller dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
-        "version" : "1.0.6"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {
@@ -14,14 +14,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin.git",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "StoreHelper",
-            dependencies: [.product(name: "Collections", package: "swift-collections")],
+            dependencies: [.product(name: "OrderedCollections", package: "swift-collections")],
             resources: [.process("Resources")])
     ]
 )

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "StoreHelper",
-            dependencies: [.product(name: "Collections", package: "swift-collections")],
+            dependencies: [.product(name: "OrderedCollections", package: "swift-collections")],
             resources: [.process("Resources")])
     ]
 )

--- a/Sources/StoreHelper/Core/StoreHelper.swift
+++ b/Sources/StoreHelper/Core/StoreHelper.swift
@@ -6,7 +6,7 @@
 //
 
 import StoreKit
-import Collections
+import OrderedCollections
 
 public typealias ProductId = String
 public typealias ShouldAddStorePaymentHandler = (_ payment: SKPayment, _ product: SKProduct) -> Bool


### PR DESCRIPTION
Pulls in only the one part of Collections that is actually used. Faster builds.